### PR TITLE
Add reset/busy so example works with breakout

### DIFF
--- a/examples/il91874_simpletest.py
+++ b/examples/il91874_simpletest.py
@@ -23,16 +23,23 @@ displayio.release_displays()
 spi = board.SPI()
 epd_cs = board.D10
 epd_dc = board.D9
+epd_reset = board.D5
+epd_busy = board.D6
 
 # Create the displayio connection to the display pins
 display_bus = displayio.FourWire(
-    spi, command=epd_dc, chip_select=epd_cs, baudrate=1000000
+    spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000
 )
 time.sleep(1)  # Wait a bit
 
 # Create the display object - the third color is red (0xff0000)
 display = adafruit_il91874.IL91874(
-    display_bus, width=264, height=176, highlight_color=0xFF0000, rotation=90
+    display_bus,
+    width=264,
+    height=176,
+    busy_pin=epd_busy,
+    highlight_color=0xFF0000,
+    rotation=90,
 )
 
 # Create a display group for our screen objects


### PR DESCRIPTION
This is also to keep eInk examples consistent.